### PR TITLE
Convert HEIC files on-the-fly when downloaded

### DIFF
--- a/src/main/java/me/tagavari/airmessageserver/connection/CommConst.java
+++ b/src/main/java/me/tagavari/airmessageserver/connection/CommConst.java
@@ -3,7 +3,7 @@ package me.tagavari.airmessageserver.connection;
 public class CommConst {
 	//Transmission header values
 	public static final int mmCommunicationsVersion = 5;
-	public static final int mmCommunicationsSubVersion = 3;
+	public static final int mmCommunicationsSubVersion = 4;
 	
 	//NHT - Net header type
 	public static final int nhtClose = 0;

--- a/src/main/java/me/tagavari/airmessageserver/connection/CommunicationsManager.java
+++ b/src/main/java/me/tagavari/airmessageserver/connection/CommunicationsManager.java
@@ -687,16 +687,19 @@ public class CommunicationsManager implements DataProxyListener<ClientRegistrati
 		}
 	}
 	
-	public boolean sendFileChunk(ClientRegistration client, short requestID, int requestIndex, long fileLength, boolean isLast, String fileGUID, byte[] chunkData, int chunkDataLength) {
+	public boolean sendFileChunk(ClientRegistration client, short requestID, int requestIndex, String updatedFileName, String updatedFileType, long fileLength, boolean isLast, byte[] chunkData, int chunkDataLength) {
 		try(AirPacker packer = AirPacker.get()) {
 			packer.packInt(CommConst.nhtAttachmentReq);
 			
 			packer.packShort(requestID);
 			packer.packInt(requestIndex);
-			if(requestIndex == 0) packer.packLong(fileLength);
+			if(requestIndex == 0) {
+				packer.packNullableString(updatedFileName);
+				packer.packNullableString(updatedFileType);
+				packer.packLong(fileLength);
+			}
 			packer.packBoolean(isLast);
 			
-			packer.packString(fileGUID);
 			packer.packPayload(chunkData, chunkDataLength);
 			
 			dataProxy.sendMessage(client, packer.toByteArray(), true);

--- a/src/main/java/me/tagavari/airmessageserver/connection/CommunicationsManager.java
+++ b/src/main/java/me/tagavari/airmessageserver/connection/CommunicationsManager.java
@@ -757,13 +757,17 @@ public class CommunicationsManager implements DataProxyListener<ClientRegistrati
 		}
 	}
 	
-	public boolean sendMassRetrievalFileChunk(ClientRegistration client, short requestID, int requestIndex, String fileName, boolean isLast, String fileGUID, byte[] chunkData, int chunkDataLength) {
+	public boolean sendMassRetrievalFileChunk(ClientRegistration client, short requestID, int requestIndex, String fileName, String downloadFileName, String downloadFileType, boolean isLast, String fileGUID, byte[] chunkData, int chunkDataLength) {
 		try(AirPacker packer = AirPacker.get()) {
 			packer.packInt(CommConst.nhtMassRetrievalFile);
 			
 			packer.packShort(requestID);
 			packer.packInt(requestIndex);
-			if(requestIndex == 0) packer.packString(fileName);
+			if(requestIndex == 0) {
+				packer.packString(fileName);
+				packer.packNullableString(downloadFileName);
+				packer.packNullableString(downloadFileType);
+			}
 			packer.packBoolean(isLast);
 			
 			packer.packString(fileGUID);

--- a/src/main/java/me/tagavari/airmessageserver/helper/ConversionHelper.java
+++ b/src/main/java/me/tagavari/airmessageserver/helper/ConversionHelper.java
@@ -1,0 +1,84 @@
+package me.tagavari.airmessageserver.helper;
+
+import me.tagavari.airmessageserver.server.Constants;
+import me.tagavari.airmessageserver.server.Main;
+import me.tagavari.airmessageserver.server.SystemAccess;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+
+public class ConversionHelper {
+    public static ConvertedFile convert(File file) throws IOException, InterruptedException, ExecutionException {
+        //Getting the file extension
+        String fileExtension = FileHelper.getExtensionByStringHandling(file.getName()).orElse(null);
+
+        //Checking if the file is HEIC
+        if("heic".equals(fileExtension)) {
+            Main.getLogger().log(Level.INFO, "Converting file " + file.getPath() + " from HEIC");
+
+            //Creating the convert directory if it doesn't exist
+            if(Constants.convertDir.isFile()) Constants.convertDir.delete();
+            if(!Constants.convertDir.exists()) Constants.convertDir.mkdir();
+
+            //Converting the file to JPEG
+            File targetFile = new File(Constants.convertDir, UUID.randomUUID() + ".jpeg");
+            try {
+                SystemAccess.convertImage("jpeg", file, targetFile);
+            } catch(IOException | InterruptedException | ExecutionException exception) {
+                //Clean up
+                targetFile.delete();
+
+                //Rethrow
+                throw exception;
+            }
+
+            //Setting the file data
+            String newFileName = file.getName().substring(0, file.getName().lastIndexOf(".")) + ".jpeg";
+            return new ConvertedFile(targetFile, true, newFileName, "image/jpeg");
+        }
+        //Otherwise checking if the file is CAF
+        else if("caf".equals(fileExtension)) {
+            Main.getLogger().log(Level.INFO, "Converting file " + file.getPath() + " from CAF");
+
+            //Creating the convert directory if it doesn't exist
+            if(Constants.convertDir.isFile()) Constants.convertDir.delete();
+            if(!Constants.convertDir.exists()) Constants.convertDir.mkdir();
+
+            //Converting the file
+            File targetFile = new File(Constants.convertDir, UUID.randomUUID() + ".mp4");
+            try {
+                SystemAccess.convertAudio("mp4f", "aac", file, targetFile);
+            } catch(IOException | InterruptedException | ExecutionException exception) {
+                //Clean up
+                targetFile.delete();
+
+                //Rethrow
+                throw exception;
+            }
+
+            String newFilename = file.getName().substring(0, file.getName().lastIndexOf(".")) + ".mp4";
+            return new ConvertedFile(targetFile, true, newFilename, "audio/mp4");
+        } else {
+            //No conversion
+            return new ConvertedFile(file, false, null, null);
+        }
+    }
+
+    public static record ConvertedFile(
+            File file, //The file to upload
+            boolean converted, //Whether this file was converted, and the file should be deleted
+            String updatedName, //The updated name of the converted file
+            String updatedType //The updated type of the converted file
+    ) implements Closeable {
+        @Override
+        public void close() throws IOException {
+            if(converted) {
+                file.delete();
+            }
+        }
+    }
+}

--- a/src/main/java/me/tagavari/airmessageserver/helper/FileHelper.java
+++ b/src/main/java/me/tagavari/airmessageserver/helper/FileHelper.java
@@ -9,6 +9,6 @@ public class FileHelper {
     public static Optional<String> getExtensionByStringHandling(String filename) {
         return Optional.ofNullable(filename)
                 .filter(f -> f.contains("."))
-                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1).toLowerCase());
     }
 }

--- a/src/main/java/me/tagavari/airmessageserver/helper/FileHelper.java
+++ b/src/main/java/me/tagavari/airmessageserver/helper/FileHelper.java
@@ -1,0 +1,14 @@
+package me.tagavari.airmessageserver.helper;
+
+import java.util.Optional;
+
+public class FileHelper {
+    /**
+     * Gets an extension from a file name
+     */
+    public static Optional<String> getExtensionByStringHandling(String filename) {
+        return Optional.ofNullable(filename)
+                .filter(f -> f.contains("."))
+                .map(f -> f.substring(filename.lastIndexOf(".") + 1));
+    }
+}

--- a/src/main/java/me/tagavari/airmessageserver/server/Constants.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/Constants.java
@@ -22,7 +22,8 @@ public class Constants {
 	static final File applicationSupportDir = new File(System.getProperty("user.home") + '/' + "Library" + '/' + "Application Support" + '/' + "AirMessage");
 	static final File uploadDir = new File(applicationSupportDir, "uploads");
 	static final File updateDir = new File(applicationSupportDir, "update");
-	
+	static final File convertDir = new File(applicationSupportDir, "convert");
+
 	//Creating the macOS version values
 	static final int[] macOSYosemiteVersion = {10, 10};
 	static final int[] macOSElCapitanVersion = {10, 11};

--- a/src/main/java/me/tagavari/airmessageserver/server/Constants.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/Constants.java
@@ -19,10 +19,10 @@ public class Constants {
 	public static final int SERVER_VERSION_CODE = 23;
 	
 	//Creating the file values
-	static final File applicationSupportDir = new File(System.getProperty("user.home") + '/' + "Library" + '/' + "Application Support" + '/' + "AirMessage");
-	static final File uploadDir = new File(applicationSupportDir, "uploads");
-	static final File updateDir = new File(applicationSupportDir, "update");
-	static final File convertDir = new File(applicationSupportDir, "convert");
+	public static final File applicationSupportDir = new File(System.getProperty("user.home") + '/' + "Library" + '/' + "Application Support" + '/' + "AirMessage");
+	public static final File uploadDir = new File(applicationSupportDir, "uploads");
+	public static final File updateDir = new File(applicationSupportDir, "update");
+	public static final File convertDir = new File(applicationSupportDir, "convert");
 
 	//Creating the macOS version values
 	static final int[] macOSYosemiteVersion = {10, 10};

--- a/src/main/java/me/tagavari/airmessageserver/server/DatabaseManager.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/DatabaseManager.java
@@ -1140,6 +1140,14 @@ public class DatabaseManager {
 						if(filePath == null) continue; //Ignoring invalid files
 						fileName = new File(filePath).getName(); //Determining the file name from its path
 					}
+
+					//Updating the file type
+					if(fileType == null) {
+						String fileExtension = FileHelper.getExtensionByStringHandling(fileName).orElse(null);
+						if("caf".equals(fileExtension)) {
+							fileType = "audio/caf";
+						}
+					}
 					
 					//Adding the file
 					files.add(new Blocks.AttachmentInfo(fileGUID,

--- a/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
@@ -70,7 +70,7 @@ public class SystemAccess {
 	 * @param output The file to write to
 	 */
 	public static void convertAudio(String fileFormat, String dataFormat, File input, File output) throws IOException, InterruptedException, ExecutionException {
-		Process process = Runtime.getRuntime().exec(new String[]{"afconvert", "-f", fileFormat, "-d", dataFormat, input.getPath(), "--o", output.getPath()});
+		Process process = Runtime.getRuntime().exec(new String[]{"afconvert", "-f", fileFormat, "-d", dataFormat, input.getPath(), "-o", output.getPath()});
 		int exitCode = process.waitFor();
 		if(exitCode != 0) {
 			//Logging the error

--- a/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
@@ -1,8 +1,10 @@
 package me.tagavari.airmessageserver.server;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -40,5 +42,23 @@ public class SystemAccess {
 	
 	public static String readProcessorArchitecture() {
 		return processForResult("uname -p");
+	}
+
+	/**
+	 * Converts an image from one format to another
+	 * @param format The format to convert to
+	 * @param input The file to convert
+	 * @param output The file to write to
+	 */
+	public static void convertImage(String format, File input, File output) throws IOException, InterruptedException, ExecutionException {
+		Process process = Runtime.getRuntime().exec(new String[]{"sips", "--setProperty", "format", format, input.getPath(), "--out", output.getPath()});
+		int exitCode = process.waitFor();
+		if(exitCode != 0) {
+			//Logging the error
+			try(BufferedReader in = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+				String errorOutput = in.lines().collect(Collectors.joining());
+				throw new ExecutionException(errorOutput, null);
+			}
+		}
 	}
 }

--- a/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
+++ b/src/main/java/me/tagavari/airmessageserver/server/SystemAccess.java
@@ -61,4 +61,23 @@ public class SystemAccess {
 			}
 		}
 	}
+
+	/**
+	 * Converts an audio file from one format to another
+	 * @param fileFormat The file format to convert to
+	 * @param dataFormat The data format to convert to
+	 * @param input The file to convert
+	 * @param output The file to write to
+	 */
+	public static void convertAudio(String fileFormat, String dataFormat, File input, File output) throws IOException, InterruptedException, ExecutionException {
+		Process process = Runtime.getRuntime().exec(new String[]{"afconvert", "-f", fileFormat, "-d", dataFormat, input.getPath(), "--o", output.getPath()});
+		int exitCode = process.waitFor();
+		if(exitCode != 0) {
+			//Logging the error
+			try(BufferedReader in = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+				String errorOutput = in.lines().collect(Collectors.joining());
+				throw new ExecutionException(errorOutput, null);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Android and all major web browsers are unable to display `.heic` files, a common image format used by Apple devices.

AirMessage Server will now convert these files automatically to `.jpeg` when a client app requests the download of a `.heic` attachment.